### PR TITLE
#15 Added drop table

### DIFF
--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,0 +1,67 @@
+import clsx from "clsx";
+import { isNil } from "lodash";
+import { ButtonHTMLAttributes } from "react";
+
+import { ThemeColor } from "../../../types/theme.types";
+import {
+  getBackgroundColor,
+  getBorderColor,
+  getTextColor,
+} from "../../../utils/theme.utils";
+
+export type ButtonVariant = "contained" | "outlined" | "text" | "auxiliary";
+
+export type ButtonSize = "sm" | "lg";
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  color?: ThemeColor;
+  variant?: ButtonVariant;
+  leftIcon?: JSX.Element;
+  rightIcon?: JSX.Element;
+  rounded?: boolean;
+  size?: ButtonSize;
+};
+
+const Button: React.FC<ButtonProps> = (props): JSX.Element | null => {
+  const {
+    children,
+    className,
+    color = "primary",
+    disabled,
+    hidden,
+    leftIcon,
+    rightIcon,
+    rounded,
+    size,
+    variant = "contained",
+  } = props;
+  const backgroundColor = getBackgroundColor(color, variant === "outlined");
+  const borderColor = getBorderColor(color);
+  const textColor = getTextColor(color, variant === "contained");
+
+  const buttonClasses = clsx({
+    ["font-semibold uppercase flex items-center gap-2.5 hover:bg-opacity-50"]:
+      true,
+    [`border ${borderColor}`]:
+      variant === "contained" || variant === "outlined",
+    [backgroundColor]: variant === "contained",
+    ["bg-transparent"]: variant !== "contained",
+    ["py-3 px-7"]: variant !== "auxiliary",
+    ["rounded"]: rounded,
+    ["text-base"]: isNil(size) || size === "lg",
+    ["text-xs"]: size === "sm",
+    ["opacity-50 cursor-not-allowed"]: disabled,
+    [textColor]: true,
+    [className || ""]: true,
+  });
+
+  return hidden ? null : (
+    <button {...props} className={buttonClasses}>
+      {leftIcon && leftIcon}
+      {children}
+      {rightIcon && rightIcon}
+    </button>
+  );
+};
+
+export default Button;

--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,0 +1,4 @@
+import Button from "./Button";
+
+export * from "./Button";
+export default Button;

--- a/src/components/common/FileInputButton/FileInputButton.tsx
+++ b/src/components/common/FileInputButton/FileInputButton.tsx
@@ -1,0 +1,48 @@
+import { useRef } from "react";
+
+import Button, { ButtonProps } from "../Button";
+
+export type FileInputButtonProps = ButtonProps & {
+  onFileSelected: (files: FileList) => void;
+};
+
+const FileInputButton: React.FunctionComponent<FileInputButtonProps> = (
+  props: FileInputButtonProps
+): JSX.Element => {
+  const fileDialog = useRef<HTMLInputElement | null>(null);
+
+  const openFileDialog = (): void => {
+    if (fileDialog.current) {
+      fileDialog.current.click();
+    }
+  };
+
+  const fileSelected = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    if (event.currentTarget.files && event.currentTarget.files.length > 0) {
+      props.onFileSelected(event.currentTarget.files);
+      if (fileDialog.current) {
+        // Clears the value of the input. Some browsers (Chromium based for sure) do not fire the onChange event if the value is the same.
+        // Ref: https://stackoverflow.com/a/11280864/8070411
+        // Bug: https://app.shortcut.com/deveron/story/1783/farm-dog-web-upload-failed-when-one-uploads-a-file-on-the-second-upload-form-where-the-progress-bar-is-right-after-a-previous#activity-1799
+        fileDialog.current.value = "";
+      }
+    }
+  };
+
+  return (
+    <>
+      <Button onClick={openFileDialog} {...props}>
+        {props.children}
+      </Button>
+      <input
+        type="file"
+        multiple
+        ref={fileDialog}
+        className="hidden"
+        onChange={fileSelected}
+      />
+    </>
+  );
+};
+
+export default FileInputButton;

--- a/src/components/common/FileInputButton/index.tsx
+++ b/src/components/common/FileInputButton/index.tsx
@@ -1,0 +1,4 @@
+import FileInputButton from "./FileInputButton";
+
+export * from "./FileInputButton";
+export default FileInputButton;

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -1,0 +1,28 @@
+import clsx from "clsx";
+import { ButtonHTMLAttributes } from "react";
+
+export type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  size?: "small" | "medium" | "large";
+};
+
+const IconButton: React.FunctionComponent<IconButtonProps> = ({
+  size = "medium",
+  ...props
+}: IconButtonProps): JSX.Element => {
+  const { children } = props;
+
+  const buttonClasses = clsx({
+    "w-8 h-8": size === "small",
+    "w-12 h-12": size === "medium",
+    "w-16 h-16": size === "large",
+    [props.className || ""]: true,
+  });
+
+  return (
+    <button className={buttonClasses} {...props}>
+      {children}
+    </button>
+  );
+};
+
+export default IconButton;

--- a/src/components/common/IconButton/index.tsx
+++ b/src/components/common/IconButton/index.tsx
@@ -1,0 +1,4 @@
+import IconButton from "./IconButton";
+
+export * from "./IconButton";
+export default IconButton;

--- a/src/types/theme.types.ts
+++ b/src/types/theme.types.ts
@@ -1,0 +1,10 @@
+export const THEME_COLORS = [
+  "primary",
+  "secondary",
+  "warning",
+  "error",
+  "success",
+  "light",
+] as const;
+
+export type ThemeColor = (typeof THEME_COLORS)[number];

--- a/src/utils/theme.utils.ts
+++ b/src/utils/theme.utils.ts
@@ -1,0 +1,98 @@
+import { ThemeColor } from "../types/theme.types";
+
+// Important: Tailwind does some treeshaking/smart stuff to not include unused styles.
+// This is why we have a getMainColor and getBackgroundColor. You could theoretically do
+// `bg-${getMainColor('primary')}` but if bg-primary-700 is not somewhere else tailwind
+// won't pick it up in the build. I could just list the strings somewhere but being more
+// explicit seems less hacky.
+
+export const getMainColor = (color: ThemeColor): string => {
+  switch (color) {
+    case "secondary":
+      return "secondary-700";
+    case "light":
+      return "white";
+    case "success":
+      return "green-600";
+    case "warning":
+      return "yellow-400";
+    case "error":
+      return "red-600";
+    case "primary":
+    default:
+      return "primary-700";
+  }
+};
+
+export const getAlternateColor = (color: ThemeColor): string => {
+  switch (color) {
+    case "secondary":
+    case "light":
+    case "success":
+    case "warning":
+    case "error":
+    case "primary":
+    default:
+      return "white";
+  }
+};
+
+export const getBackgroundColor = (
+  color: ThemeColor,
+  inverted: boolean = false
+): string => {
+  switch (color) {
+    case "secondary":
+      return inverted ? "bg-white" : "bg-secondary-700";
+    case "light":
+      return inverted ? "bg-transparent" : "bg-white";
+    case "success":
+      return inverted ? "bg-white" : "bg-green-600";
+    case "warning":
+      return inverted ? "bg-black" : "bg-yellow-400";
+    case "error":
+      return inverted ? "bg-white" : "bg-red-600";
+    case "primary":
+    default:
+      return inverted ? "bg-white" : "bg-primary-700";
+  }
+};
+
+export const getBorderColor = (color: ThemeColor): string => {
+  switch (color) {
+    case "secondary":
+      return "border-secondary-700";
+    case "light":
+      return "border-white";
+    case "success":
+      return "border-green-600";
+    case "warning":
+      return "border-yellow-400";
+    case "error":
+      return "border-red-600";
+    case "primary":
+    default:
+      return "border-primary-700";
+  }
+};
+
+export const getTextColor = (
+  color: ThemeColor,
+  inverted: boolean = false
+): string => {
+  switch (color) {
+    case "secondary":
+      return inverted ? "text-white" : "text-secondary-700";
+    case "light":
+      return inverted ? "text-black" : "text-white";
+    case "success":
+      return inverted ? "text-white" : "text-green-600";
+    case "warning":
+      return inverted ? "text-black" : "text-yellow-400";
+    case "error":
+      return inverted ? "text-white" : "text-red-600";
+    case "primary":
+    default:
+      return inverted ? "text-white" : "text-primary-700";
+  }
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,139 @@ module.exports = {
     "./src/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    fontFamily: {
+      meri: ["Merriweather"],
+      roboto: ["Roboto"],
+    },
+    extend: {
+      colors: {
+        primary: {
+          50: "#DCEEFF",
+          100: "#B9DCFF",
+          200: "#97CBFF",
+          300: "#74BAFF",
+          400: "#51A8FF",
+          500: "#2E97FF",
+          600: "#1C80E5",
+          700: "#006ACB",
+          800: "#0155B2",
+          900: "#004099",
+        },
+        secondary: {
+          50: "#FFFFFF",
+          100: "#F7F7F7",
+          200: "#E1E5E7",
+          300: "#CCD4D8",
+          400: "#A5B3BC",
+          500: "#8295A1",
+          600: "#677D8B",
+          700: "#345164",
+          800: "#1C3B50",
+          900: "#01263D",
+        },
+        red: {
+          50: "#FFEFEF",
+          100: "#FEE2E2",
+          200: "#FECACA",
+          300: "#FCA5A5",
+          400: "#FF7672",
+          500: "#FF3B3B",
+          600: "#DC2626",
+          700: "#B91C1C",
+          800: "#9E1413",
+          900: "#840B0B",
+        },
+        yellow: {
+          50: "#FEFCE8",
+          100: "#FEF9C3",
+          200: "#FEF08A",
+          300: "#FDE047",
+          400: "#FACC15",
+          500: "#EAB308",
+          600: "#CA8A04",
+          700: "#A16207",
+          800: "#854D0E",
+          900: "#713F12",
+        },
+        green: {
+          50: "#E9F6E7",
+          100: "#CCEAC4",
+          200: "#B0DEA3",
+          300: "#93D281",
+          400: "#76C65E",
+          500: "#55B938",
+          600: "#419E2A",
+          700: "#2E831D",
+          800: "#1B6A0F",
+          900: "#055102",
+        },
+      },
+      fontSize: ({ theme }) => ({
+        // Paragraph 12
+        xs: [
+          "0.75rem",
+          { lineHeight: "1rem", fontWeight: theme("fontWeight.normal") },
+        ],
+        // Paragraph 14
+        sm: [
+          "0.875rem",
+          { lineHeight: "1.25rem", fontWeight: theme("fontWeight.normal") },
+        ],
+        // Paragraph 16
+        base: [
+          "1rem",
+          { lineHeight: "1.5rem", fontWeight: theme("fontWeight.normal") },
+        ],
+        // Subtitle 2
+        lg: [
+          "1.125rem",
+          { lineHeight: "1.75rem", fontWeight: theme("fontWeight.normal") },
+        ],
+        // Subtitle 1
+        xl: [
+          "1.25rem",
+          { lineHeight: "1.75rem", fontWeight: theme("fontWeight.normal") },
+        ],
+        // Heading 6
+        "2xl": [
+          "1.25rem",
+          { lineHeight: "1.75rem", fontWeight: theme("fontWeight.medium") },
+        ],
+        // Heading 5
+        "3xl": [
+          "1.5rem",
+          { lineHeight: "1.875rem", fontWeight: theme("fontWeight.medium") },
+        ],
+        // Heading 4
+        "4xl": [
+          "1.875rem",
+          { lineHeight: "2.25rem", fontWeight: theme("fontWeight.medium") },
+        ],
+        // Heading 3
+        "5xl": [
+          "2.25rem",
+          { lineHeight: "3rem", fontWeight: theme("fontWeight.medium") },
+        ],
+        // Heading 2
+        "6xl": [
+          "3rem",
+          { lineHeight: "3.75rem", fontWeight: theme("fontWeight.semibold") },
+        ],
+        // Heading 1
+        "7xl": [
+          "3.75rem",
+          { lineHeight: "4.5rem", fontWeight: theme("fontWeight.semibold") },
+        ],
+        "8xl": [
+          "4.5rem",
+          { lineHeight: "6rem", fontWeight: theme("fontWeight.semibold") },
+        ],
+        "9xl": [
+          "6rem",
+          { lineHeight: "1", fontWeight: theme("fontWeight.semibold") },
+        ],
+      }),
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
#15

- Added the drop table skeleton
- Can add new rows and upload/display mob images.
- Added a bunch of common components to help with making things.

Testing:
- [X] Go to the drop table maker, add a new row, and select a PNG image

![image](https://user-images.githubusercontent.com/8093569/236483244-f717370a-2eea-4c67-bf30-8930448b8df5.png)
