### PR TITLE
#16 Add items to table

### DIFF
--- a/pages/rose/drop-table-maker.tsx
+++ b/pages/rose/drop-table-maker.tsx
@@ -239,6 +239,17 @@ const DropTableMaker: NextPage = () => {
     "shadow-[inset_0_-2px_4px_rgba(0,0,0,0.6)]": selectedTool === "remove",
   });
 
+  const handleCellClick = (rowIndex: number, columnIndex: number) => {
+    if (currentItem === null) {
+      return;
+    }
+    const newValue: DropTableColumn | null =
+      selectedTool === "add" ? { item: currentItem, dropType: null } : null;
+    const newRows = [...dropRows];
+    newRows[rowIndex].drops[columnIndex] = newValue;
+    setDropRows(newRows);
+  };
+
   const handleAddMobImage = (rowIndex: number, mobImage: string) => {
     const newRows = [...dropRows];
     newRows[rowIndex].mobImage = mobImage;
@@ -328,7 +339,7 @@ const DropTableMaker: NextPage = () => {
         <DropTable
           rows={dropRows}
           onAddMobImage={handleAddMobImage}
-          onCellClick={() => {}}
+          onCellClick={handleCellClick}
           onNewRow={handleAddNewRow}
         />
       </div>

--- a/src/constants/drop.constants.ts
+++ b/src/constants/drop.constants.ts
@@ -1671,3 +1671,7 @@ export const ALL_ITEMS = [
   ...ARMOR,
   ...WEAPONS,
 ];
+
+export const ALL_ITEM_MAP = new Map<number, Item>(
+  ALL_ITEMS.map((item) => [item.id, item])
+);


### PR DESCRIPTION
#16 

- Hooked up the event for adding items to the table and made a map for all items for easier loading later.

Testing:
- [X] Click the 'arrow' add tool, select an item, click on table cells, item is added/overwritten
- [X] Click the 'x box' remove tool, click on table cells, item is removed

