### PR TITLE
#17 Multiple drop tables

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "recharts": "^2.5.0",
-    "sass": "^1.62.1"
+    "sass": "^1.62.1",
+    "tailwind-merge": "^1.12.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.194",

--- a/pages/rose/drop-table-maker.tsx
+++ b/pages/rose/drop-table-maker.tsx
@@ -1,4 +1,4 @@
-import { Listbox, Transition } from "@headlessui/react";
+import { Listbox, Tab, Transition } from "@headlessui/react";
 import {
   ArchiveBoxXMarkIcon,
   ArrowDownTrayIcon,
@@ -6,11 +6,12 @@ import {
   ChevronDownIcon,
   CursorArrowRaysIcon,
   FolderIcon,
+  PlusIcon,
 } from "@heroicons/react/24/solid";
 import clsx from "clsx";
 import { NextPage } from "next";
 import NextImage from "next/image";
-import { Fragment, useMemo, useRef, useState } from "react";
+import { Fragment, useState } from "react";
 
 import PageWrapper from "../../src/components/PageWrapper/PageWrapper";
 import {
@@ -20,6 +21,8 @@ import {
 } from "../../src/constants/drop.constants";
 import { customLoader } from "../../src/utils/next.utils";
 import FileInputButton from "../../src/components/common/FileInputButton";
+import IconButton from "../../src/components/common/IconButton";
+import Button from "../../src/components/common/Button";
 
 type ItemGroupOption = {
   id: RoseItemGroup;
@@ -213,9 +216,7 @@ const DropTable = ({
           ))}
         </tbody>
       </table>
-      <button className="bg-white-500 px-8" onClick={onNewRow}>
-        +
-      </button>
+      <IconButton Icon={PlusIcon} onClick={onNewRow} />
     </>
   );
 };
@@ -264,6 +265,13 @@ const DropTableMaker: NextPage = () => {
       drops: [...Array(35)].map((x) => null),
     });
     setDropRows(newRows);
+  };
+
+  const handleAddNewTab = () => {
+    const newRows = [...dropRows];
+    newRows.push([]);
+    setDropRows(newRows);
+    setCurrentTabIndex(newRows.length - 1);
   };
 
   const handleSelectedGroupChange = (newGroup: ItemGroupOption) => {
@@ -336,12 +344,36 @@ const DropTableMaker: NextPage = () => {
             );
           })}
         </div>
-        <DropTable
-          rows={dropRows[currentTabIndex]}
-          onAddMobImage={handleAddMobImage}
-          onCellClick={handleCellClick}
-          onNewRow={handleAddNewRow}
-        />
+        <Tab.Group
+          selectedIndex={currentTabIndex}
+          onChange={setCurrentTabIndex}
+        >
+          <Tab.List>
+            {dropRows.map((row, index) => (
+              <Tab
+                key={index}
+                className={
+                  currentTabIndex === index ? "bg-secondary-500 text-white" : ""
+                }
+              >
+                Tab {index + 1}
+              </Tab>
+            ))}
+            <IconButton Icon={PlusIcon} size="sm" onClick={handleAddNewTab} />
+          </Tab.List>
+          <Tab.Panels>
+            {dropRows.map((row, index) => (
+              <Tab.Panel key={index}>
+                <DropTable
+                  rows={dropRows[index]}
+                  onAddMobImage={handleAddMobImage}
+                  onCellClick={handleCellClick}
+                  onNewRow={handleAddNewRow}
+                />
+              </Tab.Panel>
+            ))}
+          </Tab.Panels>
+        </Tab.Group>
       </div>
     </PageWrapper>
   );

--- a/pages/rose/drop-table-maker.tsx
+++ b/pages/rose/drop-table-maker.tsx
@@ -222,7 +222,8 @@ const DropTable = ({
 
 const DropTableMaker: NextPage = () => {
   const [currentItem, setCurrentItem] = useState<Item | null>(null);
-  const [dropRows, setDropRows] = useState<DropTableRow[]>([]);
+  const [dropRows, setDropRows] = useState<DropTableRow[][]>([[]]);
+  const [currentTabIndex, setCurrentTabIndex] = useState<number>(0);
   const [selectedGroup, setSelectedGroup] = useState<ItemGroupOption>(
     ROSE_ITEM_GROUPS[0]
   );
@@ -246,24 +247,23 @@ const DropTableMaker: NextPage = () => {
     const newValue: DropTableColumn | null =
       selectedTool === "add" ? { item: currentItem, dropType: null } : null;
     const newRows = [...dropRows];
-    newRows[rowIndex].drops[columnIndex] = newValue;
+    newRows[currentTabIndex][rowIndex].drops[columnIndex] = newValue;
     setDropRows(newRows);
   };
 
   const handleAddMobImage = (rowIndex: number, mobImage: string) => {
     const newRows = [...dropRows];
-    newRows[rowIndex].mobImage = mobImage;
+    newRows[currentTabIndex][rowIndex].mobImage = mobImage;
     setDropRows(newRows);
   };
 
   const handleAddNewRow = () => {
-    setDropRows((prevRows) => [
-      ...prevRows,
-      {
-        mobImage: "",
-        drops: [...Array(35)].map((x) => null),
-      },
-    ]);
+    const newRows = [...dropRows];
+    newRows[currentTabIndex].push({
+      mobImage: "",
+      drops: [...Array(35)].map((x) => null),
+    });
+    setDropRows(newRows);
   };
 
   const handleSelectedGroupChange = (newGroup: ItemGroupOption) => {
@@ -337,7 +337,7 @@ const DropTableMaker: NextPage = () => {
           })}
         </div>
         <DropTable
-          rows={dropRows}
+          rows={dropRows[currentTabIndex]}
           onAddMobImage={handleAddMobImage}
           onCellClick={handleCellClick}
           onNewRow={handleAddNewRow}

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { isNil } from "lodash";
 import { ButtonHTMLAttributes } from "react";
+import { twMerge } from "tailwind-merge";
 
 import { ThemeColor } from "../../../types/theme.types";
 import {
@@ -11,7 +12,7 @@ import {
 
 export type ButtonVariant = "contained" | "outlined" | "text" | "auxiliary";
 
-export type ButtonSize = "sm" | "lg";
+export type ButtonSize = "sm" | "md" | "lg";
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   color?: ThemeColor;
@@ -40,7 +41,7 @@ const Button: React.FC<ButtonProps> = (props): JSX.Element | null => {
   const textColor = getTextColor(color, variant === "contained");
 
   const buttonClasses = clsx({
-    ["font-semibold uppercase flex items-center gap-2.5 hover:bg-opacity-50"]:
+    ["font-semibold uppercase inline-flex items-center gap-2.5 hover:bg-opacity-50"]:
       true,
     [`border ${borderColor}`]:
       variant === "contained" || variant === "outlined",
@@ -52,11 +53,10 @@ const Button: React.FC<ButtonProps> = (props): JSX.Element | null => {
     ["text-xs"]: size === "sm",
     ["opacity-50 cursor-not-allowed"]: disabled,
     [textColor]: true,
-    [className || ""]: true,
   });
 
   return hidden ? null : (
-    <button {...props} className={buttonClasses}>
+    <button {...props} className={twMerge(buttonClasses, className)}>
       {leftIcon && leftIcon}
       {children}
       {rightIcon && rightIcon}

--- a/src/components/common/IconButton/IconButton.tsx
+++ b/src/components/common/IconButton/IconButton.tsx
@@ -1,27 +1,34 @@
 import clsx from "clsx";
-import { ButtonHTMLAttributes } from "react";
+import { twMerge } from "tailwind-merge";
 
-export type IconButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
-  size?: "small" | "medium" | "large";
+import Button, { ButtonProps } from "../Button";
+
+export type IconButtonProps = ButtonProps & {
+  Icon: React.ComponentType<{ className?: string }>;
 };
 
 const IconButton: React.FunctionComponent<IconButtonProps> = ({
-  size = "medium",
+  size = "md",
   ...props
 }: IconButtonProps): JSX.Element => {
-  const { children } = props;
+  const { children, className, Icon } = props;
 
   const buttonClasses = clsx({
-    "w-8 h-8": size === "small",
-    "w-12 h-12": size === "medium",
-    "w-16 h-16": size === "large",
-    [props.className || ""]: true,
+    "py-1 px-1": size === "sm",
+    "py-2 px-2": size === "md",
+    "py-4 px-3": size === "lg",
+  });
+
+  const iconClasses = clsx({
+    "w-4 h-4": size === "sm",
+    "w-6 h-6": size === "md",
+    "w-8 h-8": size === "lg",
   });
 
   return (
-    <button className={buttonClasses} {...props}>
-      {children}
-    </button>
+    <Button className={twMerge(buttonClasses, className)} {...props}>
+      <Icon className={iconClasses} />
+    </Button>
   );
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,6 +2467,11 @@ synckit@^0.8.5:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
 
+tailwind-merge@^1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.12.0.tgz#747d09d64a25a4864150e8930f8e436866066cc8"
+  integrity sha512-Y17eDp7FtN1+JJ4OY0Bqv9OA41O+MS8c1Iyr3T6JFLnOgLg3EvcyMKZAnQ8AGyvB5Nxm3t9Xb5Mhe139m8QT/g==
+
 tailwindcss@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.3.2.tgz#2f9e35d715fdf0bbf674d90147a0684d7054a2d3"


### PR DESCRIPTION
#17 

- Add ability to have multiple tabs so we aren't pulling all the images on screen at once

Testing:
- [X] Click the + button to add new tabs
- [X] Click the tab to switch between
- [X] Data goes to and stays on appropriate tab

